### PR TITLE
Fix double release of NSString

### DIFF
--- a/client/Mac/cli/AppDelegate.m
+++ b/client/Mac/cli/AppDelegate.m
@@ -199,7 +199,6 @@ void AppDelegate_ConnectionResultEventHandler(void* ctx, ConnectionResultEventAr
 			
 			// Making sure this should be invoked on the main UI thread.
 			[_singleDelegate performSelectorOnMainThread:@selector(rdpConnectError:) withObject:message waitUntilDone:FALSE];
-			[message release];
 		}
 	}
 }


### PR DESCRIPTION
stringWithFormat returns an autoreleased object, so manually releasing message results in a crash
